### PR TITLE
Fixed broken database handling

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -50,7 +50,8 @@ lib.callback.register("qb-garage:server:validateGarageVehicle", validateGarageVe
 local function checkOwnership(source, plate, type, house, gang)
     local pData = QBCore.Functions.GetPlayer(source)
     if type == "public" then --Public garages only for player cars
-        return MySQL.query.await('SELECT * FROM player_vehicles WHERE plate = ? AND citizenid = ?', {plate, pData.PlayerData.citizenid})
+         local result = MySQL.query.await('SELECT * FROM player_vehicles WHERE plate = ? AND citizenid = ?', {plate, pData.PlayerData.citizenid})
+         return result[1] or false
     elseif type == "house" then --House garages only for player cars that have keys of the house
         local result = MySQL.query.await('SELECT * FROM player_vehicles WHERE plate = ?', {plate})
         return result[1] and exports['qb-houses']:hasKey(result[1].license, result[1].citizenid, house)


### PR DESCRIPTION
## Description

Fixed issue with old check and return returning {} regardless of ownership and breaking other checks as you can see now it returns false if not found

The effect of this bug was allowing you to store any vehicle regardless of ownership, you would not be able to retrieve the vehicle but still removes the vehicle

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

[ x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
[ x ] My code fits the style guidelines.
[ x ] My PR fits the contribution guidelines.